### PR TITLE
Fix resize behavior

### DIFF
--- a/src/hooks/useResize.jsx
+++ b/src/hooks/useResize.jsx
@@ -16,9 +16,9 @@ export const useResize = ({ initialWidth = 200, offset = 75 } = {}) => {
     }, [])
 
     const handleMouseUp = useCallback(() => {
-        document.documentElement.removeAttribute('data-resizing')
         document.removeEventListener('mousemove', handleMouseMove)
         document.removeEventListener('mouseup', handleMouseUp)
+        document.documentElement.removeAttribute('data-resizing')
 
     }, [handleMouseMove])
 

--- a/src/hooks/useResize.jsx
+++ b/src/hooks/useResize.jsx
@@ -15,7 +15,7 @@ export const useResize = ({ initialWidth = 200, offset = 75 } = {}) => {
         const minWidth = 180
         if (e.clientX - offset > maxWidth || e.clientX - offset < minWidth) return
         setWidth(e.clientX - offset)
-    }, [])
+    }, [offset])
 
     const handleMouseUp = useCallback(() => {
         document.removeEventListener('mousemove', handleMouseMove)

--- a/src/hooks/useResize.jsx
+++ b/src/hooks/useResize.jsx
@@ -2,8 +2,10 @@ import { useCallback, useState } from 'react'
 import './useResize.css'
 
 /**
- * @param initialWidth {number}
- * @returns {[number,function(): void]}
+ * A custom hook for resizing the Sidebar
+ * @param initialWidth
+ * @param offset
+ * @returns {[number,(function(): void)|*]}
  */
 export const useResize = ({ initialWidth = 200, offset = 75 } = {}) => {
     const [width, setWidth] = useState(initialWidth)


### PR DESCRIPTION
Bug Fix - Resize Sidebar
Description: Fixes a bug where user selection ended too early and selected elements on screen.
Solved by first removing the event listeners for `mousemove`, `mouseup`, then removing the attribute `data-resizing` from the document.